### PR TITLE
Add email list API and websocket notification routes

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,12 +4,14 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
+mod routes;
+
 async fn root() -> &'static str {
     "Hello World!"
 }
 
 pub async fn start_server(token: CancellationToken) {
-    let app = Router::new().route("/", get(root));
+    let app = Router::new().route("/", get(root)).merge(routes::router());
 
     let mut listenfd = ListenFd::from_env();
     // try to first get a socket from listenfd, if that does not give us

--- a/src/server/routes/emails.rs
+++ b/src/server/routes/emails.rs
@@ -1,0 +1,41 @@
+use axum::{routing::get, Json, Router};
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Email {
+    id: u32,
+    from: &'static str,
+    to: &'static str,
+    subject: &'static str,
+    body: &'static str,
+    received_at: &'static str,
+}
+
+pub fn router() -> Router {
+    Router::new().route("/emails", get(get_all_emails))
+}
+
+async fn get_all_emails() -> Json<Vec<Email>> {
+    Json(dummy_emails())
+}
+
+pub fn dummy_emails() -> Vec<Email> {
+    vec![
+        Email {
+            id: 1,
+            from: "alerts@devsmtp.local",
+            to: "developer@example.com",
+            subject: "Welcome to DevSMTP",
+            body: "Your local SMTP server is up and running.",
+            received_at: "2026-02-21T09:00:00Z",
+        },
+        Email {
+            id: 2,
+            from: "noreply@service.local",
+            to: "developer@example.com",
+            subject: "Daily summary",
+            body: "No new activity in the last 24 hours.",
+            received_at: "2026-02-21T10:15:00Z",
+        },
+    ]
+}

--- a/src/server/routes/emails.rs
+++ b/src/server/routes/emails.rs
@@ -4,11 +4,11 @@ use serde::Serialize;
 #[derive(Clone, Debug, Serialize)]
 pub struct Email {
     id: u32,
-    from: &'static str,
-    to: &'static str,
-    subject: &'static str,
-    body: &'static str,
-    received_at: &'static str,
+    from: String,
+    to: String,
+    subject: String,
+    body: String,
+    received_at: String,
 }
 
 pub fn router() -> Router {
@@ -23,19 +23,19 @@ pub fn dummy_emails() -> Vec<Email> {
     vec![
         Email {
             id: 1,
-            from: "alerts@devsmtp.local",
-            to: "developer@example.com",
-            subject: "Welcome to DevSMTP",
-            body: "Your local SMTP server is up and running.",
-            received_at: "2026-02-21T09:00:00Z",
+            from: "alerts@devsmtp.local".to_string(),
+            to: "developer@example.com".to_string(),
+            subject: "Welcome to DevSMTP".to_string(),
+            body: "Your local SMTP server is up and running.".to_string(),
+            received_at: "2026-02-21T09:00:00Z".to_string(),
         },
         Email {
             id: 2,
-            from: "noreply@service.local",
-            to: "developer@example.com",
-            subject: "Daily summary",
-            body: "No new activity in the last 24 hours.",
-            received_at: "2026-02-21T10:15:00Z",
+            from: "noreply@service.local".to_string(),
+            to: "developer@example.com".to_string(),
+            subject: "Daily summary".to_string(),
+            body: "No new activity in the last 24 hours.".to_string(),
+            received_at: "2026-02-21T10:15:00Z".to_string(),
         },
     ]
 }

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -1,0 +1,10 @@
+use axum::Router;
+
+mod emails;
+mod notifications;
+
+pub fn router() -> Router {
+    Router::new()
+        .merge(emails::router())
+        .merge(notifications::router())
+}

--- a/src/server/routes/notifications.rs
+++ b/src/server/routes/notifications.rs
@@ -1,0 +1,61 @@
+use axum::{
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    response::Response,
+    routing::get,
+    Router,
+};
+use tokio::time::{interval, Duration};
+use tracing::debug;
+
+use super::emails::dummy_emails;
+
+pub fn router() -> Router {
+    Router::new().route("/emails/notifications", get(notifications_ws))
+}
+
+async fn notifications_ws(ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    let mut ticker = interval(Duration::from_secs(5));
+    let mut next_id = dummy_emails().len() as u32 + 1;
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {
+                let payload = serde_json::json!({
+                    "type": "new_email",
+                    "email": {
+                        "id": next_id,
+                        "from": "system@devsmtp.local",
+                        "to": "developer@example.com",
+                        "subject": format!("Dummy email #{}", next_id),
+                        "body": "This is a websocket notification from dummy data.",
+                        "received_at": "2026-02-21T10:30:00Z"
+                    }
+                });
+
+                if socket.send(Message::Text(payload.to_string().into())).await.is_err() {
+                    debug!("WebSocket client disconnected while sending notification");
+                    break;
+                }
+
+                next_id += 1;
+            }
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => {
+                        debug!("WebSocket client disconnected");
+                        break;
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(err)) => {
+                        debug!(?err, "WebSocket receive error");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple HTTP API to retrieve stored emails and a websocket endpoint to notify clients about new emails using dummy data for initial development and testing.

### Description
- Add a new `src/server/routes` module with `mod.rs` to aggregate sub-routers and register routes with the server.
- Implement `GET /emails` in `src/server/routes/emails.rs` which defines a serializable `Email` struct and returns `dummy_emails()` as JSON.
- Implement `GET /emails/notifications` in `src/server/routes/notifications.rs` as a websocket endpoint that emits periodic dummy `new_email` JSON events using `tokio::time::interval` and `axum` websocket APIs.
- Wire the new routes into the main Axum app by merging `routes::router()` in `src/server/mod.rs`.

### Testing
- Ran `cargo fmt --all` to format the code successfully.
- Ran `cargo check` which completed successfully (existing unrelated warnings in SMTP/command modules remain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c540fbc0832b80eead73d8a4387b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email retrieval endpoint providing access to messages with sender, recipient, subject, body, and timestamp details
  * Implemented WebSocket-based notifications system delivering real-time email alerts to clients

<!-- end of auto-generated comment: release notes by coderabbit.ai -->